### PR TITLE
Map page and back button

### DIFF
--- a/app/component/map/map.cjsx
+++ b/app/component/map/map.cjsx
@@ -45,10 +45,16 @@ class Map extends React.Component
         hasLocation: true
 
   updateQuery: =>
-      #center = @refs.map.getLeafletElement().getCenter()
-      #@context.router.replaceWith(@context.router.getCurrentPathname(),
-      #                            @context.router.getCurrentParams(),
-      #                            merge(@context.router.getCurrentQuery(), {zoom: @refs.map.getLeafletElement().getZoom(), lon: center.lng, lat: center.lat}))
+      center = @refs.map.getLeafletElement().getCenter()
+      @context.router.replaceWith(
+          @context.router.getCurrentPathname(),
+          @context.router.getCurrentParams(),
+          merge(@context.router.getCurrentQuery(),
+                zoom: @refs.map.getLeafletElement().getZoom()
+                # Android Chrome gets into infinite recursion always changing
+                # Leaflet map longitude by around 0.00003 from what it was set to
+                lon: center.lng.toFixed(4)
+                lat: center.lat.toFixed(4)))
 
   render: ->
     if isBrowser


### PR DESCRIPTION
When user does:
1) Open map
2) Move map 
3) Click stop icon
4) Move to stop page
5) click back

Map is now in different zoom and place than in step 4. We should keep map in same zoom level and location in these kind on cases.